### PR TITLE
Resolve resetting game state when a new player attempts to join in progress game

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -50,14 +50,14 @@ app.post('/api/joinRoom', (req, res) => {
     state[room] = joinRoom(state[room], name)
     console.log('room joined')
     res.send({status: 'SUCCESS', name, room});
+    if (Object.values(state[room].players).length === playerCount) {
+      state[room] = actionHandlers.handleGameStart(state[room]);
+    }
+    io.emit('UPDATE_STATE', {room, roomState: state[room]});
   } else {
     console.log('room full')
     res.send({status: 'FULL'});
   }
-  if (Object.values(state[room].players).length === playerCount) {
-    state[room] = actionHandlers.handleGameStart(state[room]);
-  }
-  io.emit('UPDATE_STATE', {room, roomState: state[room]});
 });
 
 app.post('/api/update', (req, res) => {


### PR DESCRIPTION
Fixed join at max room size bug - a new player attempting to join a full game would reshuffle the players and reset game state

Tested without fix, observed broken behavior. Recompiled with fix in place, and was no longer able to produce error. Game still starts as expected when max player size is reached. A player is still able to rejoin a game in progress, but this bug fix does not resolve the issue wherein the frontend no longer displays the player's action area.